### PR TITLE
Refactored grid classes to put them in an inheritance hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Supported grid sytles are:
 ```Python
 from tableformatter import FancyGrid
 
-print(generate_table(rows, grid_style=FancyGrid))
+print(generate_table(rows, grid_style=FancyGrid()))
 ╔════╤════╤════╤════╗
 ║ A1 │ A2 │ A3 │ A4 ║
 ╟────┼────┼────┼────╢

--- a/examples/color.py
+++ b/examples/color.py
@@ -9,15 +9,18 @@ from tableformatter import generate_table
 try:
     from colorama import Back
     BACK_RESET = Back.RESET
+    BACK_GREEN = Back.LIGHTGREEN_EX
     BACK_BLUE = Back.LIGHTBLUE_EX
 except ImportError:
     try:
         from colored import bg
         BACK_RESET = bg(0)
         BACK_BLUE = bg(27)
+        BACK_GREEN = bg(119)
     except ImportError:
         BACK_RESET = ''
         BACK_BLUE = ''
+        BACK_GREEN = ''
 
 rows = [('A1', 'A2', 'A3', 'A4'),
         ('B1', 'B2\nB2\nB2', 'B3', 'B4'),
@@ -27,5 +30,4 @@ rows = [('A1', 'A2', 'A3', 'A4'),
 columns = ('Col1', 'Col2', 'Col3', 'Col4')
 
 print("Table with colorful alternting rows")
-print(generate_table(rows, columns, grid_style=tf.AlternatingRowGrid(BACK_RESET, BACK_BLUE)))
-
+print(generate_table(rows, columns, grid_style=tf.AlternatingRowGrid(BACK_GREEN, BACK_BLUE)))

--- a/examples/color.py
+++ b/examples/color.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# coding=utf-8
+"""
+Simple demonstration of TableFormatter with some colored output.
+"""
+import tableformatter as tf
+from tableformatter import generate_table
+
+try:
+    from colorama import Back
+    BACK_RESET = Back.RESET
+    BACK_BLUE = Back.LIGHTBLUE_EX
+except ImportError:
+    try:
+        from colored import bg
+        BACK_RESET = bg(0)
+        BACK_BLUE = bg(27)
+    except ImportError:
+        BACK_RESET = ''
+        BACK_BLUE = ''
+
+rows = [('A1', 'A2', 'A3', 'A4'),
+        ('B1', 'B2\nB2\nB2', 'B3', 'B4'),
+        ('C1', 'C2', 'C3', 'C4'),
+        ('D1', 'D2', 'D3', 'D4')]
+
+columns = ('Col1', 'Col2', 'Col3', 'Col4')
+
+print("Table with colorful alternting rows")
+print(generate_table(rows, columns, grid_style=tf.AlternatingRowGrid(BACK_RESET, BACK_BLUE)))
+

--- a/examples/simple_object.py
+++ b/examples/simple_object.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python
 # coding=utf-8
-from tableformatter import generate_table, FancyGrid, SparseGrid, Column
-
 """
 Simple demonstration of TableFormatter with a list of objects for the table entries.
-This approach requires providing the name of the object attribute to query 
-for each cell (via attrib='attrib_name'). 
+This approach requires providing the name of the object attribute to query
+for each cell (via attrib='attrib_name').
 TableFormatter will check if the attribute is callable. If it is, it wall be called
 and the returned result will be displayed for that cell.
 """
+from tableformatter import generate_table, FancyGrid, SparseGrid, Column
 
 
 class MyRowObject(object):
@@ -44,10 +43,10 @@ print(generate_table(rows, columns, transpose=True))
 
 
 print("Table with header, transposed, FancyGrid:")
-print(generate_table(rows, columns, grid_style=FancyGrid, transpose=True))
+print(generate_table(rows, columns, grid_style=FancyGrid(), transpose=True))
 
 print("Table with header, transposed, SparseGrid:")
-print(generate_table(rows, columns, grid_style=SparseGrid, transpose=True))
+print(generate_table(rows, columns, grid_style=SparseGrid(), transpose=True))
 
 
 columns2 = (Column('Col1', attrib='field3'),

--- a/examples/simple_text.py
+++ b/examples/simple_text.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python
 # coding=utf-8
-from tableformatter import generate_table, FancyGrid, SparseGrid
 """
 Simple demonstration of TableFormatter with a list of tuples as table entries.
 TableFormatter will automatically expand the row height to handle multi-line entries.
 """
-
+import tableformatter as tf
+from tableformatter import generate_table
 
 rows = [('A1', 'A2', 'A3', 'A4'),
         ('B1', 'B2\nB2\nB2', 'B3', 'B4'),
         ('C1', 'C2', 'C3', 'C4'),
         ('D1', 'D2', 'D3', 'D4')]
-
 
 columns = ('Col1', 'Col2', 'Col3', 'Col4')
 
@@ -24,10 +23,10 @@ print(generate_table(rows, transpose=True))
 
 
 print("Basic Table, FancyGrid:")
-print(generate_table(rows, grid_style=FancyGrid))
+print(generate_table(rows, grid_style=tf.FancyGrid()))
 
 print("Basic Table, SparseGrid:")
-print(generate_table(rows, grid_style=SparseGrid))
+print(generate_table(rows, grid_style=tf.SparseGrid()))
 
 print("Table with header, AlteratingRowGrid:")
 print(generate_table(rows, columns))
@@ -38,7 +37,7 @@ print(generate_table(rows, columns, transpose=True))
 
 
 print("Table with header, transposed, FancyGrid:")
-print(generate_table(rows, columns, grid_style=FancyGrid, transpose=True))
+print(generate_table(rows, columns, grid_style=tf.FancyGrid(), transpose=True))
 
 print("Table with header, transposed, SparseGrid:")
-print(generate_table(rows, columns, grid_style=SparseGrid, transpose=True))
+print(generate_table(rows, columns, grid_style=tf.SparseGrid(), transpose=True))

--- a/tableformatter.py
+++ b/tableformatter.py
@@ -523,11 +523,11 @@ class AlternatingRowGrid(FancyGrid):
 
     This typically looks quite good, but also does a good job of conserving vertical space.
     """
-    def __init__(self, bg_reset: str=TableColors.BG_RESET, bg_color: str=TableColors.BG_COLOR_ROW) -> None:
+    def __init__(self, bg_primary: str=TableColors.BG_RESET, bg_alternate: str=TableColors.BG_COLOR_ROW) -> None:
         """Initialize the AlternatingRowGrid with the two alternating colors.
 
-        :param bg_reset: string reprsenting the default background color
-        :param bg_color: string representing the alternate background color
+        :param bg_primary: string reprsenting the primary background color starting with the 1st row
+        :param bg_alternate: string representing the alternate background color starting with the 2nd row
         """
         super().__init__()
         # Disable row dividers present in FancyGrid in order to save vertical space
@@ -535,40 +535,40 @@ class AlternatingRowGrid(FancyGrid):
         self.row_divider_span = ''
         self.row_divider_col_divider = ''
         self.row_divider_header_col_divider = ''
-        self.bg_reset = bg_reset
-        self.bg_color = bg_color
+        self.bg_reset = TableColors.BG_RESET
+        self.bg_primary = bg_primary
+        self.bg_alt = bg_alternate
 
     def border_left_span(self, row_index: Union[int, None]) -> str:
+        prefix = self.bg_reset + '║'
+        color = self.bg_reset
         if isinstance(row_index, int):
             if row_index % 2 == 0:
-                return '║'
+                color = self.bg_primary
             else:
-                return self.bg_reset + '║' + self.bg_color
-        return '║'
+                color = self.bg_alt
+        return prefix + color
 
     def border_right_span(self, row_index: Union[int, None]) -> str:
-        if isinstance(row_index, int):
-            if row_index % 2 == 0:
-                return '║'
-            else:
-                return self.bg_reset + '║'
-        return '║'
+        return self.bg_reset + '║'
 
     def col_divider_span(self, row_index : Union[int, None]) -> str:
+        color = self.bg_reset
         if isinstance(row_index, int):
             if row_index % 2 == 0:
-                return '│'
+                color = self.bg_primary
             else:
-                return self.bg_reset + self.bg_color + '│'
-        return '│'
+                color = self.bg_alt
+        return color + '│'
 
     def header_col_divider_span(self, row_index: Union[int, None]) -> str:
+        color = self.bg_reset
         if isinstance(row_index, int):
             if row_index % 2 == 0:
-                return '║'
+                color = self.bg_primary
             else:
-                return self.bg_reset + self.bg_color + '║'
-        return '║'
+                color = self.bg_alt
+        return color + '║'
 
 
 DEFAULT_GRID = AlternatingRowGrid()

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -10,6 +10,7 @@ import tableformatter as tf
 
 # Make the test results reproducible regardless of what color libraries are installed
 tf.TableColors.set_color_library('none')
+tf.set_default_grid(tf.AlternatingRowGrid('', ''))
 
 WITH_HEADER = '''
 ╔══════╤══════╤══════╤══════╗
@@ -91,7 +92,7 @@ def test_basic_fancy_grid(rows):
 ║ D1 │ D2 │ D3 │ D4 ║
 ╚════╧════╧════╧════╝
 '''.lstrip('\n')
-    table = tf.generate_table(rows, grid_style=tf.FancyGrid)
+    table = tf.generate_table(rows, grid_style=tf.FancyGrid())
     assert table == expected
 
 def test_basic_sparse_grid(rows):
@@ -102,7 +103,7 @@ def test_basic_sparse_grid(rows):
      B2         
  C1  C2  C3  C4 
  D1  D2  D3  D4 \n                \n'''.lstrip('\n')
-    table = tf.generate_table(rows, grid_style=tf.SparseGrid)
+    table = tf.generate_table(rows, grid_style=tf.SparseGrid())
     assert table == expected
 
 def test_table_with_header(rows, cols):
@@ -127,7 +128,7 @@ def test_table_with_header_transposed_fancy(rows, cols):
 ║ Col4 ║ A4 │ B4 │ C4 │ D4 ║
 ╚══════╩════╧════╧════╧════╝
 '''.lstrip('\n')
-    table = tf.generate_table(rows, cols, grid_style=tf.FancyGrid, transpose=True)
+    table = tf.generate_table(rows, cols, grid_style=tf.FancyGrid(), transpose=True)
     assert table == expected
 
 def test_table_with_header_transposed_sparse(rows, cols):
@@ -138,7 +139,7 @@ def test_table_with_header_transposed_sparse(rows, cols):
            B2         
  Col3  A3  B3  C3  D3 
  Col4  A4  B4  C4  D4 \n                      \n'''.lstrip('\n')
-    table = tf.generate_table(rows, cols, grid_style=tf.SparseGrid, transpose=True)
+    table = tf.generate_table(rows, cols, grid_style=tf.SparseGrid(), transpose=True)
     assert table == expected
 
 
@@ -195,7 +196,7 @@ def test_object_table_fancy_grid(obj_rows, obj_cols):
 ║ D1   │ D2   │ D3   │ D4   ║
 ╚══════╧══════╧══════╧══════╝
 '''.lstrip('\n')
-    table = tf.generate_table(obj_rows, obj_cols, grid_style=tf.FancyGrid)
+    table = tf.generate_table(obj_rows, obj_cols, grid_style=tf.FancyGrid())
     assert table == expected
 
 def test_object_table_sparse_grid(obj_rows, obj_cols):
@@ -206,7 +207,7 @@ def test_object_table_sparse_grid(obj_rows, obj_cols):
      B2         
  C1  C2  C3  C4 
  D1  D2  D3  D4 \n                \n'''.lstrip('\n')
-    table = tf.generate_table(obj_rows, obj_cols, grid_style=tf.SparseGrid)
+    table = tf.generate_table(obj_rows, obj_cols, grid_style=tf.SparseGrid())
     assert table == expected
 
 def test_object_table_columns_rearranged(obj_rows):


### PR DESCRIPTION
Refactored grid classes to put them in an inheritance hierarchy with an abstract base class at the root.

generate_table() now takes an instance of a Grid class for grid_style instead of a class type.

There is a global DEFAULT_GRID which can be overriden with the set_default_grid() method.

AlternatingRowGrid now takes two optional arguments in its initializer: bg_primary and bg_alternate for the two alternating colors.

Also:
- Added the start of a color.py example for showcasing colored output
- Updated README
- Minor formatting tweaks to the examples