### PR TITLE
Replace non-ASCII quotes in .coveragerc with ASCII quotes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -20,5 +20,5 @@ precision = 1
 
 
 [html]
-# (string, default “htmlcov”): where to write the HTML report files.
+# (string, default "htmlcov"): where to write the HTML report files.
 directory = htmlcov


### PR DESCRIPTION
This is a fix so that unit tests will work on Windows with newer versions of the coverage module, see this issue for more info: https://github.com/nedbat/coveragepy/issues/913